### PR TITLE
Correct spelling mistakes in "download engine" text and reword

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -202,7 +202,7 @@ void Engine::compare_versions(QString date,QString n_date){
           msgBox.setDefaultButton(QMessageBox::Ok);
           QPushButton *p = new QPushButton("Quit",nullptr);
           msgBox.addButton(p,QMessageBox::NoRole);
-          msgBox.button(QDialogButtonBox::Ok)->setText("Install"); // this might not work
+          msgBox.button(QMessageBox::Ok)->setText("Install");
           int ret = msgBox.exec();
           switch (ret) {
             case QMessageBox::Ok:
@@ -228,7 +228,7 @@ void Engine::evoke_engine_check(){
           QPushButton *p = new QPushButton("Quit",nullptr);
           msgBox.addButton(p,QMessageBox::NoRole);
           msgBox.setDefaultButton(QMessageBox::Ok);
-          msgBox.button(QDialogButtonBox::Ok)->setText("Install"); // this might not work
+          msgBox.button(QMessageBox::Ok)->setText("Install");
 
           int ret = msgBox.exec();
           switch (ret) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -202,7 +202,7 @@ void Engine::compare_versions(QString date,QString n_date){
           msgBox.setDefaultButton(QMessageBox::Ok);
           QPushButton *p = new QPushButton("Quit",nullptr);
           msgBox.addButton(p,QMessageBox::NoRole);
-          msgBox.button(QDialogButtonBox::Ok).setText("Install"); // this might not work
+          msgBox.button(QDialogButtonBox::Ok)->setText("Install"); // this might not work
           int ret = msgBox.exec();
           switch (ret) {
             case QMessageBox::Ok:
@@ -228,7 +228,7 @@ void Engine::evoke_engine_check(){
           QPushButton *p = new QPushButton("Quit",nullptr);
           msgBox.addButton(p,QMessageBox::NoRole);
           msgBox.setDefaultButton(QMessageBox::Ok);
-          msgBox.button(QDialogButtonBox::Ok).setText("Install"); // this might not work
+          msgBox.button(QDialogButtonBox::Ok)->setText("Install"); // this might not work
 
           int ret = msgBox.exec();
           switch (ret) {


### PR DESCRIPTION


The text to download a first or updated version of youtube-dl contained some spelling errors and some unclear wording, so I've rewritten it to perhaps be clearer:

_Plumber requires an updated version of its video download engine. Would you like to install the updated version now?
Choose Install to download and install the modified version of youtube-dl (1.4MB). Cancel will proceed with the existing engine version, which may not work successfully._

I've also attempted to change the text of the standard OK button from "OK" to "Install", because buttons with labels that describe what they do are easier to understand; the user doesn't have to carefully read the question to get the sense of it, because it is obvious that "Install" installs and "Cancel" doesn't, whereas with "OK" and "Cancel" it depends on exactly how the question is worded.

The code change to set the text on the button might not work; I have not compiled the change and Qt C++ isn't my thing, so it may need changing!

